### PR TITLE
ENTESB-12251 - [Hawtio OCP 3.11] OSGi Server page blank in Karaf Fuse app

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -295,6 +295,10 @@
           <startupFeatures>
             <feature>framework</feature>
             <feature>fabric8-karaf-checks</feature>
+            <!-- the following features (instance and system) are optional and can be omitted if you don't need to
+                 see the OSGi Server information on Fuse Console -->
+            <feature>instance</feature>
+            <feature>system</feature>
           </startupFeatures>
           <bootFeatures>
             <feature>wrap</feature>


### PR DESCRIPTION
https://issues.redhat.com/browse/ENTESB-12251