### PR TITLE
ENTESB-13943 - Arquillian cube test doesn't work with 7.6 on OCP 4.4 (7.7)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <fuse.bom.version>7.3.0.fuse-730058-redhat-00001</fuse.bom.version>
 
     <!-- The following dependencies will be added to Fuse bom in next versions -->
-    <arquillian-cube.version>1.9.2</arquillian-cube.version>
+    <arquillian-cube.version>1.18.2</arquillian-cube.version>
     <cxf.plugin.version>3.2.7.fuse-730019-redhat-00001</cxf.plugin.version>
 
     <swagger.version>1.5.18.fuse70-1-redhat-1</swagger.version>


### PR DESCRIPTION
https://issues.redhat.com/browse/ENTESB-13943

(cherry picked from commit 9981bc61b42d8ef81b4e0103917064d38481b634)