### PR TITLE
ENTESB-12238:  Quickstarts arquillian test fail

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <version.maven-bundle-plugin>2.3.7</version.maven-bundle-plugin>
 
     <!-- configure the versions you want to use here -->
-    <fuse.bom.version>7.8.0.fuse-sb2-780004</fuse.bom.version>
+    <fuse.bom.version>7.8.0.fuse-sb2-780010</fuse.bom.version>
 
     <!-- The following dependencies will be added to Fuse bom in next versions -->
     <arquillian-cube.version>1.18.2</arquillian-cube.version>
@@ -55,7 +55,7 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-      <!-- Spring Boot (2) BOM is needed to get kubernetes-assertions and arquillian versions -->
+      <!-- Spring Boot (2) BOM is needed to get arquillian versions -->
       <dependency>
         <groupId>org.jboss.redhat-fuse</groupId>
         <artifactId>fuse-springboot-bom</artifactId>
@@ -148,14 +148,13 @@
     </dependency>
     <dependency>
       <groupId>io.fabric8</groupId>
-      <artifactId>kubernetes-assertions</artifactId>
+      <artifactId>kubernetes-model</artifactId>
       <scope>test</scope>
     </dependency>
 
     <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <version>2.4.1</version>
+      <groupId>io.fabric8</groupId>
+      <artifactId>kubernetes-client</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/src/test/java/io/fabric8/tests/integration/KubernetesIntegrationKT.java
+++ b/src/test/java/io/fabric8/tests/integration/KubernetesIntegrationKT.java
@@ -18,13 +18,17 @@ package io.fabric8.tests.integration;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
 
+import org.arquillian.cube.kubernetes.api.Session;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static io.fabric8.kubernetes.assertions.Assertions.assertThat;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodList;
+import io.fabric8.kubernetes.client.internal.readiness.Readiness;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(Arquillian.class)
 @RunAsClient
@@ -33,8 +37,20 @@ public class KubernetesIntegrationKT {
     @ArquillianResource
     KubernetesClient client;
 
+    @ArquillianResource
+    public Session session;
+
     @Test
     public void testAppProvisionsRunningPods() throws Exception {
-        assertThat(client).deployments().pods().isPodReadyForPeriod();
+        boolean foundReadyPod = false;
+
+        PodList podList = client.pods().inNamespace(session.getNamespace()).list();
+        for (Pod p : podList.getItems()) {
+            if (!p.getMetadata().getName().endsWith("build") && !p.getMetadata().getName().endsWith("deploy")) {
+                assertTrue(p.getMetadata().getName() + " is not ready", Readiness.isReady(p));
+                foundReadyPod = true;
+            }
+        }
+        assertTrue("Found no ready pods in namespace", foundReadyPod);
     }
 }


### PR DESCRIPTION
Removed kubernetes-assertion dependency in favor of kubernetes-client
