### PR TITLE
[ENTESB-15424]Quickstarts don't expose routes on OCP 4.x

### DIFF
--- a/src/main/fabric8/route.yml
+++ b/src/main/fabric8/route.yml
@@ -1,3 +1,6 @@
+
+apiVersion: "route.openshift.io/v1"
+kind: Route
 spec:
   to:
     kind: Service


### PR DESCRIPTION
(cherry picked from commit 7d4bab7b1b3a4268c32e33a472ca442bff027403)